### PR TITLE
Add ability to configure cache sizes in json-schema-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ apply(plugin: "idea");
 apply(plugin: "eclipse");
 
 group = "com.github.fge";
-version = "1.2.6-SNAPSHOT";
+version = "1.2.6";
 sourceCompatibility = "1.6";
 targetCompatibility = "1.6"; // defaults to sourceCompatibility
 

--- a/src/main/java/com/github/fge/jsonschema/core/load/SchemaLoader.java
+++ b/src/main/java/com/github/fge/jsonschema/core/load/SchemaLoader.java
@@ -62,9 +62,6 @@ public final class SchemaLoader
     private static final MessageBundle BUNDLE
         = MessageBundles.getBundle(JsonSchemaCoreMessageBundle.class);
 
-    private static final String CACHE_SIZE_PROPERTY_NAME = "com.github.fge.jsonschema.loaderCacheSize";
-    private static final int DEFAULT_CACHE_SIZE = 4096;
-
     /**
      * The URI manager
      */

--- a/src/main/java/com/github/fge/jsonschema/core/load/SchemaLoader.java
+++ b/src/main/java/com/github/fge/jsonschema/core/load/SchemaLoader.java
@@ -62,6 +62,9 @@ public final class SchemaLoader
     private static final MessageBundle BUNDLE
         = MessageBundles.getBundle(JsonSchemaCoreMessageBundle.class);
 
+    private static final String CACHE_SIZE_PROPERTY_NAME = "com.github.fge.jsonschema.loaderCacheSize";
+    private static final int DEFAULT_CACHE_SIZE = 4096;
+
     /**
      * The URI manager
      */
@@ -101,20 +104,18 @@ public final class SchemaLoader
         manager = new URIManager(cfg);
         preloadedSchemas = ImmutableMap.copyOf(cfg.getPreloadedSchemas());
 
-        final CacheBuilder<Object, Object> cacheBuilder = cfg.getEnableCache()
-            ? CacheBuilder.newBuilder()
-            : CacheBuilder.from(CacheBuilderSpec.disableCaching());
-        
-        cache = cacheBuilder.build(new CacheLoader<URI, JsonNode>()
-        {
-            @Nonnull
-            @Override
-            public JsonNode load(@Nonnull final URI key)
-                throws ProcessingException
+        cache = CacheBuilder.newBuilder()
+            .maximumSize(cfg.getEnableCache() ? cfg.getCacheSize() : 0) // cache size zero disables caching
+            .build(new CacheLoader<URI, JsonNode>()
             {
-                return manager.getContent(key);
-            }
-        });
+                @Nonnull
+                @Override
+                public JsonNode load(@Nonnull final URI key)
+                    throws ProcessingException
+                {
+                    return manager.getContent(key);
+                }
+            });
     }
 
     /**

--- a/src/main/java/com/github/fge/jsonschema/core/load/configuration/LoadingConfiguration.java
+++ b/src/main/java/com/github/fge/jsonschema/core/load/configuration/LoadingConfiguration.java
@@ -97,6 +97,14 @@ public final class LoadingConfiguration
     final boolean enableCache;
 
     /**
+     * Cache size
+     *
+     * if enableCache is false, this field is ignored.
+     * enableCache = true && cacheSize = 0 == enableCache = false
+     */
+    final int cacheSize;
+
+    /**
      * Dereferencing mode
      *
      * @see SchemaLoader
@@ -166,6 +174,7 @@ public final class LoadingConfiguration
         parserFeatures = EnumSet.copyOf(builder.parserFeatures);
         reader = buildReader();
         enableCache = builder.enableCache;
+        cacheSize = builder.cacheSize;
     }
 
     /**
@@ -241,6 +250,16 @@ public final class LoadingConfiguration
      */
     public boolean getEnableCache() {
         return enableCache;
+    }
+
+    /**
+     * Return the size of the cache to use
+     * note that this do not affect preloadedSchema that are always cached
+     *
+     * @return the size of the cache, if enabled
+     */
+    public int getCacheSize() {
+        return cacheSize;
     }
 
     /**

--- a/src/main/java/com/github/fge/jsonschema/core/load/configuration/LoadingConfigurationBuilder.java
+++ b/src/main/java/com/github/fge/jsonschema/core/load/configuration/LoadingConfigurationBuilder.java
@@ -83,6 +83,11 @@ public final class LoadingConfigurationBuilder
     boolean enableCache = true;
 
     /**
+     * Cache size is 4096 by default
+     */
+    int cacheSize = 4096;
+
+    /**
      * Dereferencing mode
      *
      * @see SchemaLoader
@@ -133,6 +138,7 @@ public final class LoadingConfigurationBuilder
         preloadedSchemas = Maps.newHashMap(cfg.preloadedSchemas);
         parserFeatures = EnumSet.copyOf(cfg.parserFeatures);
         enableCache = cfg.enableCache;
+        cacheSize = cfg.cacheSize;
     }
 
     /**
@@ -146,6 +152,21 @@ public final class LoadingConfigurationBuilder
     public LoadingConfigurationBuilder setEnableCache(final boolean enableCache)
     {
         this.enableCache = enableCache;
+        return this;
+    }
+
+    /**
+     * How many schemas should be cached
+     * <p>Note if enableCache is false this setting is ignored</p>
+     * <p>Note setting enableCache to false or this to zero both effectively disable the cache</p>
+     * <p>Note that this does <b>not</b> affect preloaded schemas</p>
+     *
+     * @param cacheSize if loaded schemas have to be cached
+     * @return this
+     */
+    public LoadingConfigurationBuilder setCacheSize(final int cacheSize)
+    {
+        this.cacheSize = cacheSize;
         return this;
     }
     

--- a/src/main/java/com/github/fge/jsonschema/core/processing/CachingProcessor.java
+++ b/src/main/java/com/github/fge/jsonschema/core/processing/CachingProcessor.java
@@ -53,6 +53,9 @@ public final class CachingProcessor<IN extends MessageProvider, OUT extends Mess
     private static final MessageBundle BUNDLE
         = MessageBundles.getBundle(JsonSchemaCoreMessageBundle.class);
 
+    public static final String CACHE_SIZE_PROPERTY_NAME = "com.github.fge.jsonschema.processorCacheSize";
+    public static final int DEFAULT_CACHE_SIZE = 4096;
+
     /**
      * The wrapped processor
      */
@@ -83,21 +86,29 @@ public final class CachingProcessor<IN extends MessageProvider, OUT extends Mess
         this(processor, Equivalences.<IN>equals());
     }
 
+    public CachingProcessor(final Processor<IN, OUT> processor,
+        final Equivalence<IN> equivalence)
+    {
+        this(processor, equivalence, Integer.getInteger(CACHE_SIZE_PROPERTY_NAME, DEFAULT_CACHE_SIZE));
+    }
     /**
      * Main constructor
      *
      * @param processor the processor
      * @param equivalence an equivalence to use for cache keys
-     * @throws NullPointerException processor or equivalence are null
+     * @param cacheSize the size of the cache, zero disables it
+     * @throws NullPointerException processor or equivalence
      */
     public CachingProcessor(final Processor<IN, OUT> processor,
-        final Equivalence<IN> equivalence)
+        final Equivalence<IN> equivalence, final int cacheSize)
     {
         BUNDLE.checkNotNull(processor, "processing.nullProcessor");
         BUNDLE.checkNotNull(equivalence, "processing.nullEquivalence");
         this.processor = processor;
         this.equivalence = equivalence;
-        cache = CacheBuilder.newBuilder().build(loader());
+        cache = CacheBuilder.newBuilder()
+                .maximumSize(cacheSize)
+                .build(loader());
     }
 
     @Override

--- a/src/test/java/com/github/fge/jsonschema/core/load/SchemaLoaderTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/load/SchemaLoaderTest.java
@@ -183,7 +183,9 @@ public final class SchemaLoaderTest
         });
 
         final LoadingConfiguration cfg = LoadingConfiguration.newBuilder()
-            .addScheme("foo", downloader).setEnableCache(false).freeze();
+            .addScheme("foo", downloader)
+            .setEnableCache(false)
+            .freeze();
         final SchemaLoader loader = new SchemaLoader(cfg);
 
         loader.get(uri);
@@ -207,7 +209,10 @@ public final class SchemaLoaderTest
         });
 
         final LoadingConfiguration cfg = LoadingConfiguration.newBuilder()
-            .addScheme("foo", downloader).setEnableCache(true).setCacheSize(0).freeze();
+            .addScheme("foo", downloader)
+            .setEnableCache(true)
+            .setCacheSize(0)
+            .freeze();
         final SchemaLoader loader = new SchemaLoader(cfg);
 
         loader.get(uri);

--- a/src/test/java/com/github/fge/jsonschema/core/load/SchemaLoaderTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/load/SchemaLoaderTest.java
@@ -100,7 +100,7 @@ public final class SchemaLoaderTest
         final SchemaTree tree = loader.get(URI.create(location));
 
         assertEquals(tree.getLoadingRef().toURI(),
-            URI.create("http://toto/b#"));
+                URI.create("http://toto/b#"));
     }
 
     @Test
@@ -152,12 +152,10 @@ public final class SchemaLoaderTest
         throws ProcessingException, IOException
     {
         final URI uri = URI.create("foo:/baz#");
-        final URIDownloader downloader = spy(new URIDownloader()
-        {
+        final URIDownloader downloader = spy(new URIDownloader() {
             @Override
             public InputStream fetch(final URI source)
-                throws IOException
-            {
+                    throws IOException {
                 return new ByteArrayInputStream(BYTES);
             }
         });
@@ -176,12 +174,10 @@ public final class SchemaLoaderTest
         throws ProcessingException, IOException
     {
         final URI uri = URI.create("foo:/baz#");
-        final URIDownloader downloader = spy(new URIDownloader()
-        {
+        final URIDownloader downloader = spy(new URIDownloader() {
             @Override
             public InputStream fetch(final URI source)
-                throws IOException
-            {
+                    throws IOException {
                 return new ByteArrayInputStream(BYTES);
             }
         });
@@ -194,5 +190,28 @@ public final class SchemaLoaderTest
         loader.get(uri);
         verify(downloader, times(2)).fetch(uri);
     }
-    
+
+    @Test
+    public void schemasCacheCanBeDisabledViaCacheSize()
+        throws ProcessingException, IOException
+    {
+        final URI uri = URI.create("foo:/baz#");
+        final URIDownloader downloader = spy(new URIDownloader()
+        {
+            @Override
+            public InputStream fetch(final URI source)
+                throws IOException
+            {
+                return new ByteArrayInputStream(BYTES);
+            }
+        });
+
+        final LoadingConfiguration cfg = LoadingConfiguration.newBuilder()
+            .addScheme("foo", downloader).setEnableCache(true).setCacheSize(0).freeze();
+        final SchemaLoader loader = new SchemaLoader(cfg);
+
+        loader.get(uri);
+        loader.get(uri);
+        verify(downloader, times(2)).fetch(uri);
+    }
 }

--- a/src/test/java/com/github/fge/jsonschema/core/processing/CachingProcessorTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/processing/CachingProcessorTest.java
@@ -26,6 +26,7 @@ import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.core.util.equivalence.Equivalences;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.load.MessageBundles;
+import com.google.common.cache.CacheBuilder;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -87,6 +88,23 @@ public final class CachingProcessorTest
         p.process(report, input);
 
         verify(processor, only()).process(anyReport(), same(input));
+        verify(report, times(2)).mergeWith(anyReport());
+    }
+
+
+    @Test
+    public void cachedValueIsProcessedTwiceWithMaximumSizeZero()
+        throws ProcessingException
+    {
+        final Processor<In, Out> p = new CachingProcessor<In, Out>(processor,
+            Equivalences.<In>identity(), 0);
+
+        final ProcessingReport report = mock(ProcessingReport.class);
+
+        p.process(report, input);
+        p.process(report, input);
+
+        verify(processor, times(2)).process(anyReport(), same(input));
         verify(report, times(2)).mergeWith(anyReport());
     }
 


### PR DESCRIPTION
Context: The CachingProcessors, due to their infinite caching,
are leading to memory exhaustion on some of our long running
service nodes.